### PR TITLE
Bump MCP SDK to 1.29, add Zod constraints and types exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.27.1",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "zod": "^4.3.6"
       },
       "bin": {
@@ -1883,9 +1883,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,13 @@
   "description": "An MCP server",
   "type": "module",
   "main": "dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
   "bin": {
     "my-mcp-server": "dist/index.js"
   },
@@ -29,7 +36,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/tools/greet.ts
+++ b/src/tools/greet.ts
@@ -7,7 +7,7 @@ export const config = {
   title: 'Greet',
   description: 'Greet someone by name',
   inputSchema: {
-    name: z.string().describe('Name to greet'),
+    name: z.string().min(1).max(200).describe('Name to greet'),
   },
   annotations: {
     readOnlyHint: true,


### PR DESCRIPTION
## Summary
- Bump `@modelcontextprotocol/sdk` to 1.29
- Add Zod `min`/`max` constraints to greet tool input
- Export types for downstream consumers

## Test plan
- [ ] CI passes (lint, typecheck, build)
- [ ] `npm run build` produces clean dist