### PR TITLE
feat: add Resources primitive example

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -121,10 +121,32 @@ server.prompt(yourPrompt.name, yourPrompt.description, yourPrompt.schema, yourPr
 
 ## Resource 추가
 
+Resource는 클라이언트에 **데이터**를 노출합니다 (Tool은 **동작**을 수행). 실제 예시는 `src/resources/server-info.ts` 참고.
+
+`src/resources/your-resource.ts` 생성:
+
 ```ts
-server.resource("example://data", "Example Resource", async () => ({
-  contents: [{ uri: "example://data", text: "리소스 내용" }]
-}));
+export const name = 'your-resource';
+export const uri = 'info://your/resource';
+
+export const metadata = {
+  title: 'Your Resource',
+  description: '이 resource가 노출하는 데이터',
+  mimeType: 'application/json',
+};
+
+export async function handler(resourceUri: URL) {
+  return {
+    contents: [{ uri: resourceUri.href, mimeType: metadata.mimeType, text: '...' }],
+  };
+}
+```
+
+`src/index.ts`에 등록:
+
+```ts
+import * as yourResource from './resources/your-resource.js';
+server.registerResource(yourResource.name, yourResource.uri, yourResource.metadata, yourResource.handler);
 ```
 
 ## HTTP 트랜스포트
@@ -261,16 +283,19 @@ npx @modelcontextprotocol/inspector node dist/index.js
 
 ```
 src/
-├── index.ts              # 서버 진입점 — Tool/Prompt 등록 + 트랜스포트
+├── index.ts              # 서버 진입점 — Tool/Resource/Prompt 등록 + 트랜스포트
 ├── config.ts             # 환경변수 설정
 ├── helpers.ts            # ok() / err() 응답 헬퍼
 ├── tools/
 │   └── greet.ts          # 예시 Tool + annotations (교체해서 사용)
+├── resources/
+│   └── server-info.ts    # 서버 메타데이터 Resource 예시 (교체해서 사용)
 └── prompts/
     └── hello.ts          # 예시 Prompt (교체해서 사용)
 tests/
 ├── greet.test.js         # Tool 테스트
 ├── helpers.test.js       # 헬퍼 테스트
+├── server-info.test.js   # Resource 테스트
 └── hello.test.js         # Prompt 테스트
 ```
 

--- a/README.md
+++ b/README.md
@@ -121,10 +121,32 @@ server.prompt(yourPrompt.name, yourPrompt.description, yourPrompt.schema, yourPr
 
 ## Adding Resources
 
+Resources expose **data** to the client (Tools perform **actions**). See `src/resources/server-info.ts` for a working example.
+
+Create `src/resources/your-resource.ts`:
+
 ```ts
-server.resource("example://data", "Example Resource", async () => ({
-  contents: [{ uri: "example://data", text: "Resource content here" }]
-}));
+export const name = 'your-resource';
+export const uri = 'info://your/resource';
+
+export const metadata = {
+  title: 'Your Resource',
+  description: 'What this resource exposes',
+  mimeType: 'application/json',
+};
+
+export async function handler(resourceUri: URL) {
+  return {
+    contents: [{ uri: resourceUri.href, mimeType: metadata.mimeType, text: '...' }],
+  };
+}
+```
+
+Register in `src/index.ts`:
+
+```ts
+import * as yourResource from './resources/your-resource.js';
+server.registerResource(yourResource.name, yourResource.uri, yourResource.metadata, yourResource.handler);
 ```
 
 ## HTTP Transport
@@ -261,16 +283,19 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 
 ```
 src/
-├── index.ts              # Server entry — tool/prompt registration + transport
+├── index.ts              # Server entry — tool/resource/prompt registration + transport
 ├── config.ts             # Environment variable config
 ├── helpers.ts            # ok() / err() response helpers
 ├── tools/
 │   └── greet.ts          # Example tool with annotations (replace with your own)
+├── resources/
+│   └── server-info.ts    # Example resource exposing server metadata (replace)
 └── prompts/
     └── hello.ts          # Example prompt (replace with your own)
 tests/
 ├── greet.test.js         # Tool tests
 ├── helpers.test.js       # Helper tests
+├── server-info.test.js   # Resource tests
 └── hello.test.js         # Prompt tests
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { parseConfig } from './config.js';
 import * as greet from './tools/greet.js';
+import * as serverInfo from './resources/server-info.js';
 import * as hello from './prompts/hello.js';
 
 const require = createRequire(import.meta.url);
@@ -22,10 +23,8 @@ server.registerTool(greet.name, greet.config, greet.handler);
 // import { registerNoteTools } from './notes/tools.js';
 // registerNoteTools(server, config);
 
-// Resources — expose data to the client (replace with your own)
-server.resource("example://data", "Example Resource", async () => ({
-  contents: [{ uri: "example://data", text: "Replace with your resource data" }],
-}));
+// Resources — expose data to the client. Use registerResource for full control.
+server.registerResource(serverInfo.name, serverInfo.uri, serverInfo.metadata, serverInfo.handler);
 
 // Prompts — guided workflows for common tasks
 server.prompt(hello.name, hello.description, hello.schema, hello.handler);

--- a/src/resources/server-info.ts
+++ b/src/resources/server-info.ts
@@ -1,0 +1,41 @@
+/**
+ * Example MCP Resource — exposes server metadata (name, version, runtime) at a
+ * fixed URI. Resources are how you expose data to the client (in contrast to
+ * Tools which perform actions). Replace with your own resource.
+ */
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../../package.json") as { name: string; version: string };
+
+export const name = "server-info";
+export const uri = "info://server/status";
+
+export const metadata = {
+  title: "Server Info",
+  description: "Server metadata: name, version, and runtime info.",
+  mimeType: "application/json",
+};
+
+export const description = metadata.description;
+
+export async function handler(resourceUri: URL) {
+  const payload = {
+    name: pkg.name,
+    version: pkg.version,
+    runtime: {
+      node: process.version,
+      platform: process.platform,
+      arch: process.arch,
+    },
+  };
+  return {
+    contents: [
+      {
+        uri: resourceUri.href,
+        mimeType: metadata.mimeType,
+        text: JSON.stringify(payload, null, 2),
+      },
+    ],
+  };
+}

--- a/tests/server-info.test.js
+++ b/tests/server-info.test.js
@@ -1,0 +1,28 @@
+import { describe, test, expect } from '@jest/globals';
+import { handler, name, uri, metadata } from '../dist/resources/server-info.js';
+
+describe('server-info resource', () => {
+  test('has stable name and uri', () => {
+    expect(name).toBe('server-info');
+    expect(uri).toBe('info://server/status');
+    expect(metadata.mimeType).toBe('application/json');
+  });
+
+  test('returns contents shaped per MCP spec with server metadata', async () => {
+    const result = await handler(new URL(uri));
+    expect(Array.isArray(result.contents)).toBe(true);
+    expect(result.contents).toHaveLength(1);
+
+    const [entry] = result.contents;
+    expect(entry.uri).toBe(uri);
+    expect(entry.mimeType).toBe('application/json');
+    expect(typeof entry.text).toBe('string');
+
+    const payload = JSON.parse(entry.text);
+    expect(typeof payload.name).toBe('string');
+    expect(typeof payload.version).toBe('string');
+    expect(payload.runtime.node).toBe(process.version);
+    expect(payload.runtime.platform).toBe(process.platform);
+    expect(payload.runtime.arch).toBe(process.arch);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/resources/server-info.ts` — a minimal working Resource exposing server name/version/runtime as JSON at `info://server/status`, following the same module pattern as `src/tools/greet.ts` (exports `name`, `uri`, `metadata`, `handler`).
- Registers it in `src/index.ts` via `server.registerResource(...)`, replacing the placeholder `server.resource(...)` call (which also had its `name`/`uri` arguments swapped per SDK v1.29 signature).
- Adds `tests/server-info.test.js` verifying name/uri/metadata and the `contents` shape, including runtime metadata matching `process.version`/`platform`/`arch`.
- Expands the "Adding Resources" section in `README.md` and `README.ko.md` with the module + `registerResource` pattern and updates the project tree.

No new runtime deps. The doubled teaching surface (Tools + Resources) gives users a working reference for both MCP primitives.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 4 suites, 10 tests pass (adds `server-info.test.js`)
- [x] `npm run lint` — clean
- [ ] CI green on PR