### PR TITLE
feat: add Prompts primitive + test audit

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -89,24 +89,27 @@ server.registerTool(yourTool.name, yourTool.config, yourTool.handler);
 
 ## Prompt 추가
 
+Prompt는 클라이언트가 사용자에게 노출하거나 모델에 주입할 수 있는, 파라미터화된 재사용 메시지 템플릿입니다. SDK v1.29+에서는 `registerPrompt`로 `title` + `description` + Zod `argsSchema`를 함께 등록하세요. 템플릿 예시는 `src/prompts/code-review.ts` 참고.
+
 `src/prompts/your-prompt.ts` 생성:
 
 ```ts
 import { z } from 'zod';
 
 export const name = 'your-prompt';
+export const title = 'Your Prompt';
 export const description = '가이드 워크플로우 설명';
 
-export const schema = {
-  param: z.string().optional().describe('선택 파라미터'),
+export const argsSchema = {
+  param: z.string().min(1).describe('필수 파라미터'),
 };
 
-export function handler({ param }: { param?: string }) {
+export function handler({ param }: { param: string }) {
   return {
     description,
     messages: [{
       role: 'user' as const,
-      content: { type: 'text' as const, text: `프롬프트 텍스트 ${param ?? '기본값'}` },
+      content: { type: 'text' as const, text: `프롬프트 텍스트 ${param}` },
     }],
   };
 }
@@ -116,7 +119,11 @@ export function handler({ param }: { param?: string }) {
 
 ```ts
 import * as yourPrompt from './prompts/your-prompt.js';
-server.prompt(yourPrompt.name, yourPrompt.description, yourPrompt.schema, yourPrompt.handler);
+server.registerPrompt(
+  yourPrompt.name,
+  { title: yourPrompt.title, description: yourPrompt.description, argsSchema: yourPrompt.argsSchema },
+  yourPrompt.handler,
+);
 ```
 
 ## Resource 추가
@@ -291,12 +298,14 @@ src/
 ├── resources/
 │   └── server-info.ts    # 서버 메타데이터 Resource 예시 (교체해서 사용)
 └── prompts/
-    └── hello.ts          # 예시 Prompt (교체해서 사용)
+    ├── hello.ts          # 무인자 Prompt 예시 (교체해서 사용)
+    └── code-review.ts    # Zod 검증 포함 템플릿 Prompt
 tests/
 ├── greet.test.js         # Tool 테스트
 ├── helpers.test.js       # 헬퍼 테스트
 ├── server-info.test.js   # Resource 테스트
-└── hello.test.js         # Prompt 테스트
+├── hello.test.js         # Prompt 테스트
+└── code-review.test.js   # 템플릿 Prompt 테스트
 ```
 
 ## 스크립트

--- a/README.md
+++ b/README.md
@@ -89,24 +89,27 @@ server.registerTool(yourTool.name, yourTool.config, yourTool.handler);
 
 ## Adding Prompts
 
+Prompts are reusable, parameterized message templates the client can surface to the user or feed to the model. Use `registerPrompt` (SDK v1.29+) for full control — `title` + `description` + Zod-validated `argsSchema`. See `src/prompts/code-review.ts` for a templated example.
+
 Create `src/prompts/your-prompt.ts`:
 
 ```ts
 import { z } from 'zod';
 
 export const name = 'your-prompt';
+export const title = 'Your Prompt';
 export const description = 'Guided workflow description';
 
-export const schema = {
-  param: z.string().optional().describe('Optional parameter'),
+export const argsSchema = {
+  param: z.string().min(1).describe('Required parameter'),
 };
 
-export function handler({ param }: { param?: string }) {
+export function handler({ param }: { param: string }) {
   return {
     description,
     messages: [{
       role: 'user' as const,
-      content: { type: 'text' as const, text: `Prompt text with ${param ?? 'default'}` },
+      content: { type: 'text' as const, text: `Prompt text with ${param}` },
     }],
   };
 }
@@ -116,7 +119,11 @@ Register in `src/index.ts`:
 
 ```ts
 import * as yourPrompt from './prompts/your-prompt.js';
-server.prompt(yourPrompt.name, yourPrompt.description, yourPrompt.schema, yourPrompt.handler);
+server.registerPrompt(
+  yourPrompt.name,
+  { title: yourPrompt.title, description: yourPrompt.description, argsSchema: yourPrompt.argsSchema },
+  yourPrompt.handler,
+);
 ```
 
 ## Adding Resources
@@ -291,12 +298,14 @@ src/
 ├── resources/
 │   └── server-info.ts    # Example resource exposing server metadata (replace)
 └── prompts/
-    └── hello.ts          # Example prompt (replace with your own)
+    ├── hello.ts          # Zero-arg prompt example (replace with your own)
+    └── code-review.ts    # Templated prompt with Zod-validated args
 tests/
 ├── greet.test.js         # Tool tests
 ├── helpers.test.js       # Helper tests
 ├── server-info.test.js   # Resource tests
-└── hello.test.js         # Prompt tests
+├── hello.test.js         # Prompt tests
+└── code-review.test.js   # Templated prompt tests
 ```
 
 ## Scripts

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { parseConfig } from './config.js';
 import * as greet from './tools/greet.js';
 import * as serverInfo from './resources/server-info.js';
 import * as hello from './prompts/hello.js';
+import * as codeReview from './prompts/code-review.js';
 
 const require = createRequire(import.meta.url);
 const { name, version } = require('../package.json') as { name: string; version: string };
@@ -26,8 +27,18 @@ server.registerTool(greet.name, greet.config, greet.handler);
 // Resources — expose data to the client. Use registerResource for full control.
 server.registerResource(serverInfo.name, serverInfo.uri, serverInfo.metadata, serverInfo.handler);
 
-// Prompts — guided workflows for common tasks
+// Prompts — guided workflows for common tasks. Use registerPrompt for full control
+// (title + description + argsSchema config object).
 server.prompt(hello.name, hello.description, hello.schema, hello.handler);
+server.registerPrompt(
+  codeReview.name,
+  {
+    title: codeReview.title,
+    description: codeReview.description,
+    argsSchema: codeReview.argsSchema,
+  },
+  codeReview.handler,
+);
 
 const transport = new StdioServerTransport();
 

--- a/src/prompts/code-review.ts
+++ b/src/prompts/code-review.ts
@@ -1,0 +1,47 @@
+/**
+ * Example MCP Prompt — templated code review prompt with Zod-validated arguments.
+ * Prompts are reusable, parameterized message templates the client can surface to
+ * the user or feed to the model. Use `registerPrompt` (v1.29+) for the config-object
+ * API with title/description/argsSchema.
+ */
+import { z } from 'zod';
+
+export const name = 'code-review';
+export const title = 'Code Review';
+export const description = 'Ask the model to review a snippet of code in the given language.';
+
+export const argsSchema = {
+  language: z
+    .enum(['js', 'ts', 'python', 'go'])
+    .describe('Programming language of the snippet.'),
+  code: z.string().min(1).describe('Source code to review (non-empty).'),
+};
+
+const languageLabel: Record<'js' | 'ts' | 'python' | 'go', string> = {
+  js: 'JavaScript',
+  ts: 'TypeScript',
+  python: 'Python',
+  go: 'Go',
+};
+
+export function handler({
+  language,
+  code,
+}: {
+  language: 'js' | 'ts' | 'python' | 'go';
+  code: string;
+}) {
+  const label = languageLabel[language];
+  return {
+    description,
+    messages: [
+      {
+        role: 'user' as const,
+        content: {
+          type: 'text' as const,
+          text: `Review this ${label} code for bugs, readability, and idiomatic style. Be specific and actionable.\n\n\`\`\`${language}\n${code}\n\`\`\``,
+        },
+      },
+    ],
+  };
+}

--- a/tests/code-review.test.js
+++ b/tests/code-review.test.js
@@ -1,0 +1,65 @@
+import { describe, test, expect } from '@jest/globals';
+import { z } from 'zod';
+import {
+  handler,
+  argsSchema,
+  name,
+  title,
+  description,
+} from '../dist/prompts/code-review.js';
+
+describe('code-review prompt', () => {
+  test('has stable identity metadata', () => {
+    expect(name).toBe('code-review');
+    expect(title).toBe('Code Review');
+    expect(typeof description).toBe('string');
+    expect(description.length).toBeGreaterThan(0);
+  });
+
+  describe('argsSchema (Zod)', () => {
+    const shape = z.object(argsSchema);
+
+    test('accepts valid language + non-empty code', () => {
+      expect(shape.safeParse({ language: 'ts', code: 'const x = 1;' }).success).toBe(true);
+    });
+
+    test('rejects empty code', () => {
+      const result = shape.safeParse({ language: 'js', code: '' });
+      expect(result.success).toBe(false);
+    });
+
+    test('rejects unsupported language', () => {
+      const result = shape.safeParse({ language: 'ruby', code: 'puts 1' });
+      expect(result.success).toBe(false);
+    });
+
+    test('rejects missing fields', () => {
+      expect(shape.safeParse({ language: 'ts' }).success).toBe(false);
+      expect(shape.safeParse({ code: 'x' }).success).toBe(false);
+    });
+  });
+
+  describe('handler', () => {
+    test('returns a single user text message with interpolated language label and code', () => {
+      const code = 'function add(a, b) { return a + b }';
+      const result = handler({ language: 'js', code });
+
+      expect(result.description).toBe(description);
+      expect(result.messages).toHaveLength(1);
+
+      const [msg] = result.messages;
+      expect(msg.role).toBe('user');
+      expect(msg.content.type).toBe('text');
+      expect(msg.content.text).toContain('JavaScript');
+      expect(msg.content.text).toContain(code);
+      expect(msg.content.text).toContain('```js');
+    });
+
+    test('uses correct language label per enum value', () => {
+      const code = 'x = 1';
+      expect(handler({ language: 'ts', code }).messages[0].content.text).toContain('TypeScript');
+      expect(handler({ language: 'python', code }).messages[0].content.text).toContain('Python');
+      expect(handler({ language: 'go', code }).messages[0].content.text).toContain('Go');
+    });
+  });
+});

--- a/tests/greet.test.js
+++ b/tests/greet.test.js
@@ -1,13 +1,15 @@
 import { describe, test, expect } from '@jest/globals';
+import { z } from 'zod';
 import { handler, config } from '../dist/tools/greet.js';
 
 describe('greet tool', () => {
   test('returns greeting with name', async () => {
     const result = await handler({ name: 'World' });
     expect(result.content[0].text).toBe('Hello, World!');
+    expect(result).not.toHaveProperty('isError');
   });
 
-  test('handles different names', async () => {
+  test('interpolates different names verbatim', async () => {
     const result = await handler({ name: 'MCP' });
     expect(result.content[0].text).toBe('Hello, MCP!');
   });
@@ -15,5 +17,18 @@ describe('greet tool', () => {
   test('has safety annotations', () => {
     expect(config.annotations.readOnlyHint).toBe(true);
     expect(config.annotations.destructiveHint).toBe(false);
+    expect(config.annotations.idempotentHint).toBe(true);
+    expect(config.annotations.openWorldHint).toBe(false);
+  });
+
+  test('input schema rejects empty name (Zod)', () => {
+    const shape = z.object(config.inputSchema);
+    expect(shape.safeParse({ name: '' }).success).toBe(false);
+  });
+
+  test('input schema rejects name longer than 200 chars (Zod)', () => {
+    const shape = z.object(config.inputSchema);
+    expect(shape.safeParse({ name: 'x'.repeat(201) }).success).toBe(false);
+    expect(shape.safeParse({ name: 'x'.repeat(200) }).success).toBe(true);
   });
 });

--- a/tests/hello.test.js
+++ b/tests/hello.test.js
@@ -1,20 +1,37 @@
 import { describe, test, expect } from '@jest/globals';
-import { handler } from '../dist/prompts/hello.js';
+import { z } from 'zod';
+import { handler, schema, description } from '../dist/prompts/hello.js';
 
 describe('hello prompt', () => {
   test('returns English greeting by default', () => {
     const result = handler({});
+    expect(result.messages).toHaveLength(1);
     expect(result.messages[0].role).toBe('user');
+    expect(result.messages[0].content.type).toBe('text');
     expect(result.messages[0].content.text).toBe('Write a friendly greeting.');
   });
 
-  test('returns Korean greeting', () => {
+  test('returns Korean greeting branch', () => {
     const result = handler({ language: 'ko' });
-    expect(result.messages[0].content.text).toContain('인사말');
+    expect(result.messages[0].content.text).toBe('친근한 인사말을 작성해주세요.');
   });
 
-  test('includes description', () => {
+  test('returns Japanese greeting branch', () => {
+    const result = handler({ language: 'ja' });
+    expect(result.messages[0].content.text).toBe('フレンドリーな挨拶を書いてください。');
+  });
+
+  test('includes description on result', () => {
     const result = handler({});
-    expect(result.description).toBeDefined();
+    expect(result.description).toBe(description);
+  });
+
+  test('schema accepts supported languages and rejects unknown ones (Zod)', () => {
+    const shape = z.object(schema);
+    expect(shape.safeParse({}).success).toBe(true);
+    expect(shape.safeParse({ language: 'en' }).success).toBe(true);
+    expect(shape.safeParse({ language: 'ko' }).success).toBe(true);
+    expect(shape.safeParse({ language: 'ja' }).success).toBe(true);
+    expect(shape.safeParse({ language: 'fr' }).success).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Adds `src/prompts/code-review.ts` — a templated prompt example with Zod `argsSchema` (`language` enum, non-empty `code`). Registered in `src/index.ts` via `server.registerPrompt` (SDK v1.29+), mirroring the `registerTool` / `registerResource` pattern already in use.
- Audits and tightens existing tests: `greet.test.js` and `hello.test.js` now exercise real Zod schema validation (bounds on `greet` name, enum acceptance/rejection on `hello` language) in addition to the handler invariants already covered.
- Adds `tests/code-review.test.js` verifying schema rejects empty code + unknown languages, and handler produces the correctly-shaped user message with interpolated language label + fenced code block.
- Updates `README.md` + `README.ko.md` Prompts sections to show the new `registerPrompt` pattern and list the new example file.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 5 suites / 21 tests pass locally
- [x] `npm run lint` clean
- [ ] CI green on PR