### PR TITLE
docs: add create-starter install path to Quick Start

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -36,13 +36,18 @@ MCP 서버를 만들고, push로 배포하세요. 시크릿 0개.
 
 ## 빠른 시작
 
-```bash
-git clone https://github.com/starter-series/mcp-server-starter.git my-mcp-server
-cd my-mcp-server
-rm -rf .git && git init
+**[create-starter](https://github.com/starter-series/create-starter) 사용** (권장):
 
-npm install
-npm run dev
+```bash
+npx @starter-series/create my-mcp-server --template mcp-server
+cd my-mcp-server && npm install && npm run dev
+```
+
+**또는 직접 clone:**
+
+```bash
+git clone https://github.com/starter-series/mcp-server-starter my-mcp-server
+cd my-mcp-server && npm install && npm run dev
 ```
 
 ## Tool 추가

--- a/README.md
+++ b/README.md
@@ -36,13 +36,18 @@ Build your MCP server. One-click publish. Zero secrets needed.
 
 ## Quick Start
 
-```bash
-git clone https://github.com/starter-series/mcp-server-starter.git my-mcp-server
-cd my-mcp-server
-rm -rf .git && git init
+**Via [create-starter](https://github.com/starter-series/create-starter)** (recommended):
 
-npm install
-npm run dev
+```bash
+npx @starter-series/create my-mcp-server --template mcp-server
+cd my-mcp-server && npm install && npm run dev
+```
+
+**Or clone directly:**
+
+```bash
+git clone https://github.com/starter-series/mcp-server-starter my-mcp-server
+cd my-mcp-server && npm install && npm run dev
 ```
 
 ## Adding Tools


### PR DESCRIPTION
## Summary
- Add `npx @starter-series/create my-mcp-server --template mcp-server` as the recommended first option in Quick Start, keeping direct-clone as fallback.
- Mirror the same structure in `README.ko.md` with Korean headings.

## Test plan
- [ ] CI passes (lint, build, tests, security scans)
- [ ] Render check: both README files show two code blocks under Quick Start