### PR TITLE
chore: bump Node to >=22 (Node 20 EOL 2026-04-30)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "version:sync": "node -e \"console.log(JSON.parse(require('fs').readFileSync('package.json','utf8')).version)\""
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
Node 20 reached end-of-life on 2026-04-30. Bumps `engines.node` and CI `node-version` to 22 (active LTS through 2027-04). GitHub Actions runner default flips to Node 24 on 2026-06-02 (https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

## Test plan
- [ ] CI green on Node 22