### PR TITLE
docs(changelog): drop dangling scaffold comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,3 @@ release feed without duplicating maintenance.
 
 ## [Unreleased]
 
-<!-- Future entries land here. Manual edits are welcome — the workflow
-     prepends BELOW this header so it never overwrites in-flight notes. -->


### PR DESCRIPTION
Cosmetic followup. The scaffold's HTML comment block ('Future entries land here…') gets shoved below each new release entry by the prepend logic, so after a few releases the layout drifts. Drop the comment — the workflow file's own header comment already documents the prepend semantics.