### PR TITLE
chore: P0 supply-chain + UX hardening sweep (2026-05-07 audit)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -49,7 +49,7 @@ jobs:
       # EBADPLATFORM on this ubuntu runner. Uncomment below and change the job-level
       # `runs-on: ubuntu-latest` to `runs-on: macos-latest`.
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Check licenses
         run: npx license-checker --failOn "GPL-2.0;GPL-3.0;AGPL-3.0"

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,4 +12,8 @@ export default {
       lines: 95,
     },
   },
+  // text reporters only: avoids writing coverage/lcov-report/*.html into
+  // the workspace, which CodeQL would otherwise scan and flag for XSS in
+  // jest's bundled report viewer (sorter.js).
+  coverageReporters: ['text', 'text-summary', 'json-summary'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "typescript-eslint": "^8.59.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@babel/code-frame": {


### PR DESCRIPTION
Combines P0 fixes from the 2026-05-07 audit. Contents vary per repo (see file diffs):

**Cross-repo (Node)**
- Every `npm ci` → `npm ci --ignore-scripts` (Shai-Hulud / PackageGate primary infection vector — lifecycle scripts are the most exploited path)
- Lockfile sync where `engines.node` was stale at `>=20`

**Per-repo bug fixes (where applicable)**
- discord-bot: `safeRespond` deferred → `editReply` (was incorrectly using `followUp`, leaving ghost 'Bot is thinking…' messages)
- telegram-bot: `safeReply` non-Grammy errors swallowed (was rethrowing, contradicting the file's contract)
- electron: `autoUpdater` errors forwarded to renderer + 3-fail cache purge
- vscode-extension: `vsix` glob safety (fail explicitly if 0 or >1 matches)
- vscode-extension: CHANGELOG placeholder `[0.1.0] - YYYY-MM-DD` removed (now matches sibling scaffolds)
- cloudflare-pages: KV NaN recovery now logs + sets `X-Counter-Recovered` header
- docker-deploy: rollback-failure cleanup (move broken compose to .failed.yml)
- react-native: auth-context `exp`/`iss` validation on rehydrate
- discord/telegram: Railway CLI version-pinned to `@4.6.3` (was unpinned global `latest`)
- discord/telegram: `npm test` adds `--coverage` so the existing `coverageThreshold` is no longer inert

**Sources**
- [CISA — npm ecosystem compromise](https://www.cisa.gov/news-events/alerts/2025/09/23/widespread-supply-chain-compromise-impacting-npm-ecosystem)
- [Microsoft — Shai-Hulud 2.0](https://www.microsoft.com/en-us/security/blog/2025/12/09/shai-hulud-2-0-guidance-for-detecting-investigating-and-defending-against-the-supply-chain-attack/)

## Test plan
- [ ] CI green
- [ ] Local `npm ci --ignore-scripts` succeeds in fresh clone (no native modules required for this template)