### PR TITLE
chore: pause maintenance cron until ci.yml fixed

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,8 +1,11 @@
 name: Maintenance
 
 on:
-  schedule:
-    - cron: '0 0 * * 1' # Every Monday 00:00 UTC
+  # TODO(2026-05-21): cron paused — weekly maintenance failing in CI.
+  # Re-enable after diagnosing the broken ci.yml step in a dedicated session.
+  # Original cadence: '0 0 * * 1' (Mondays 00:00 UTC)
+  # schedule:
+  #   - cron: '0 0 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/README.ko.md
+++ b/README.ko.md
@@ -22,17 +22,39 @@ MCP 서버를 만들고, push로 배포하세요. 시크릿 0개.
 
 ---
 
-## 포함 사항
+## 이 스타터에 대해
 
-- **MCP SDK** — `@modelcontextprotocol/sdk` + stdio 트랜스포트
-- **TypeScript** — Strict 모드, ES2022, Zod 스키마 검증
-- **Safety Annotations** — 모든 도구에 readOnly/destructive/idempotent 힌트
-- **Prompts** — 가이드 워크플로우 템플릿
-- **응답 헬퍼** — `ok()`과 `err()`로 일관된 도구 응답
-- **Config** — 환경변수 파싱 패턴
-- **CI** — gitleaks, npm audit, 라이선스 검사, ESLint, 빌드, 테스트
-- **CD** — OIDC trusted publishing으로 npm 배포 (시크릿 0개)
-- **Dependabot** — 의존성 + GitHub Actions 자동 업데이트
+**현재 구현됨**
+
+- MCP SDK — `@modelcontextprotocol/sdk` + stdio 트랜스포트
+- TypeScript — Strict 모드, ES2022, Zod 스키마 검증
+- Safety annotations — 모든 도구에 readOnly/destructive/idempotent 힌트
+- Prompts — `registerPrompt` 기반 가이드 워크플로우 템플릿 (SDK v1.29+)
+- Resources — 메타데이터 + 핸들러 패턴의 데이터 노출
+- 응답 헬퍼 — `ok()`과 `err()`로 일관된 도구 응답
+- Config — 환경변수 파싱 패턴
+- CI — gitleaks, npm audit, 라이선스 검사, ESLint, 빌드, 테스트
+- CodeQL — 정적 보안 분석 (push/PR + 주간)
+- CD — OIDC trusted publishing으로 npm 배포 (시크릿 0개)
+- Dependabot — 의존성 + GitHub Actions 자동 업데이트
+
+**계획됨**
+
+공개 로드맵에는 없습니다. 스타터는 의도적으로 완결된 상태이며, 다운스트림 프로젝트가 확장합니다. 호환성 깨지는 변경 (Node EOL, SDK 메이저)은 Dependabot으로 들어옵니다.
+
+**설계 의도**
+
+1분 안에 배포 가능한 MCP 서버를 만들 수 있게 합니다. 로컬 MCP 클라이언트가 전부 stdio를 쓰므로 stdio가 기본값입니다. HTTP 트랜스포트는 인라인 예제로만 보여드리고 (아래 참조) 기본 의존성을 키우지 않습니다. OIDC 배포라 컨트리뷰터가 npm 토큰을 붙여 넣을 일이 없습니다. Tool 이름은 모듈 접두사를 붙여 전역 고유성을 유지합니다 — 서버 간 이름 충돌이 가장 흔한 함정입니다.
+
+**비목표**
+
+- 인증 primitive, HMAC 서명, rate-limit, 감사 로깅, human-in-the-loop 인프라. 이런 것은 호스트가 들고 있을 일이지 서버 템플릿이 들 일이 아닙니다.
+- 기본 스캐폴드에 Express / HTTP 트랜스포트 포함. 템플릿은 작게 유지하고, HTTP는 필요한 사람을 위한 문서로만 제공합니다.
+- 로깅, 트레이싱, 관측성 스택의 선택지를 강요하지 않습니다.
+
+**Redacted**
+
+없음. 공개 템플릿.
 
 ## 빠른 시작
 

--- a/README.md
+++ b/README.md
@@ -22,17 +22,39 @@ Build your MCP server. One-click publish. Zero secrets needed.
 
 ---
 
-## What You Get
+## About This Starter
 
-- **MCP SDK** — `@modelcontextprotocol/sdk` with stdio transport
-- **TypeScript** — Strict mode, ES2022 target, Zod-validated tool schemas
-- **Safety Annotations** — readOnly/destructive/idempotent hints on every tool
-- **Prompts** — Guided workflow templates for common tasks
-- **Response Helpers** — `ok()` and `err()` for consistent tool responses
-- **Config** — Environment variable parsing pattern
-- **CI** — gitleaks, npm audit, license compliance, ESLint, build, test
-- **CD** — OIDC trusted publishing to npm (zero secrets needed)
-- **Dependabot** — Automated dependency + GitHub Actions updates
+**Currently implemented**
+
+- MCP SDK — `@modelcontextprotocol/sdk` with stdio transport
+- TypeScript — Strict mode, ES2022 target, Zod-validated schemas
+- Safety annotations — readOnly/destructive/idempotent hints on every tool
+- Prompts — Guided workflow templates via `registerPrompt` (SDK v1.29+)
+- Resources — Data exposure pattern with metadata + handler
+- Response helpers — `ok()` and `err()` for consistent tool responses
+- Config — Environment variable parsing pattern
+- CI — gitleaks, npm audit, license compliance, ESLint, build, test
+- CodeQL — Static security analysis (push/PR + weekly)
+- CD — OIDC trusted publishing to npm (zero secrets needed)
+- Dependabot — Automated dependency + GitHub Actions updates
+
+**Planned**
+
+Nothing on a public roadmap. The starter is intentionally finished; downstream projects extend it. Breaking-change waves (Node EOL, SDK majors) land via Dependabot.
+
+**Design intent**
+
+Bootstrap a publishable MCP server in under a minute. Stdio is the default because every local MCP client speaks it; HTTP transport is shown inline (see below) rather than bundled, to keep the dependency surface minimal. OIDC publishing means contributors never paste an npm token. Globally-unique tool names are enforced by convention — prefix with your module name, since name collisions across servers are the most common foot-gun.
+
+**Non-goals**
+
+- Auth primitives, HMAC signing, rate-limiting, audit logging, human-in-the-loop infra. Those belong in a host, not a server template.
+- Express / HTTP transport in the default scaffold. Template stays small; HTTP is documented for those who need it.
+- Opinionated logging, tracing, or observability stack. Pick what fits downstream.
+
+**Redacted**
+
+None. Public template.
 
 ## Quick Start
 


### PR DESCRIPTION
Cron disabled until weekly maintenance ci.yml step diagnosed in dedicated session. workflow_dispatch remains available.