### PR TITLE
chore: pause maintenance cron until ci.yml fixed (clean rebase of #41)

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,8 +1,11 @@
 name: Maintenance
 
 on:
-  schedule:
-    - cron: '0 0 * * 1' # Every Monday 00:00 UTC
+  # TODO(2026-05-21): cron paused — weekly maintenance failing in CI.
+  # Re-enable after diagnosing the broken ci.yml step in a dedicated session.
+  # Original cadence: '0 0 * * 1' (Mondays 00:00 UTC)
+  # schedule:
+  #   - cron: '0 0 * * 1'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Clean rebase of #41 — same single intent (comment out the maintenance.yml cron schedule, keep workflow_dispatch) without the README sweep that conflicted with main.

#41 became CONFLICTING after 7 days of main churn. This is the minimum change to ship that intent.

`workflow_dispatch` remains available for manual runs.