### PR TITLE
[codex] Harden MCP server package contract

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -200,9 +200,9 @@ server.registerResource(yourResource.name, yourResource.uri, yourResource.metada
 ```ts
 import express from 'express';
 import { randomUUID } from 'node:crypto';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { createServer } from 'my-mcp-server';
 
 const app = express();
 app.use(express.json());
@@ -232,7 +232,7 @@ app.post('/mcp', async (req, res) => {
     if (id) sessions.delete(id);
   };
 
-  const server = createServer(); // your McpServer factory
+  const server = createServer();
   await server.connect(transport);
   if (transport.sessionId) sessions.set(transport.sessionId, transport);
   await transport.handleRequest(req, res);

--- a/README.md
+++ b/README.md
@@ -200,9 +200,9 @@ This starter uses **stdio** (the standard for local MCP servers). If you need HT
 ```ts
 import express from 'express';
 import { randomUUID } from 'node:crypto';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import { createServer } from 'my-mcp-server';
 
 const app = express();
 app.use(express.json());
@@ -232,7 +232,7 @@ app.post('/mcp', async (req, res) => {
     if (id) sessions.delete(id);
   };
 
-  const server = createServer(); // your McpServer factory
+  const server = createServer();
   await server.connect(transport);
   if (transport.sessionId) sessions.set(transport.sessionId, transport);
   await transport.handleRequest(req, res);

--- a/package.json
+++ b/package.json
@@ -3,16 +3,20 @@
   "version": "1.0.0",
   "description": "An MCP server",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "dist/server.js",
+  "types": "./dist/server.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/server.d.ts",
+      "default": "./dist/server.js"
+    },
+    "./cli": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
   },
   "bin": {
-    "my-mcp-server": "dist/index.js"
+    "my-mcp-server": "./dist/index.js"
   },
   "files": [
     "dist"
@@ -23,7 +27,7 @@
     "start": "node dist/index.js",
     "lint": "eslint src/",
     "pretest": "npm run build",
-    "test": "node --experimental-vm-modules node_modules/.bin/jest --coverage",
+    "test": "node --experimental-vm-modules node_modules/.bin/jest --coverage --runInBand",
     "format": "prettier --write src/",
     "format:check": "prettier --check src/",
     "version:patch": "npm version patch --no-git-tag-version",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,9 @@
 #!/usr/bin/env node
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { parseConfig } from './config.js';
-import { name, version } from './pkg.js';
-import * as greet from './tools/greet.js';
-import * as serverInfo from './resources/server-info.js';
-import * as hello from './prompts/hello.js';
-import * as codeReview from './prompts/code-review.js';
+import { createServer } from './server.js';
 
 const config = parseConfig();
-
-const server = new McpServer({
-  name,
-  version,
-});
 
 const fatal = (label: string, value: unknown): never => {
   // stderr so the parent MCP client sees the crash; stdout is the transport.
@@ -21,28 +11,7 @@ const fatal = (label: string, value: unknown): never => {
   process.exit(1);
 };
 
-// Tools — use registerTool for full control (annotations, title)
-server.registerTool(greet.name, greet.config, greet.handler);
-// To pass config to tool handlers in multi-module setups:
-// import { registerNoteTools } from './notes/tools.js';
-// registerNoteTools(server, config);
-
-// Resources — expose data to the client. Use registerResource for full control.
-server.registerResource(serverInfo.name, serverInfo.uri, serverInfo.metadata, serverInfo.handler);
-
-// Prompts — guided workflows for common tasks. Use registerPrompt for full control
-// (title + description + argsSchema config object).
-server.prompt(hello.name, hello.description, hello.schema, hello.handler);
-server.registerPrompt(
-  codeReview.name,
-  {
-    title: codeReview.title,
-    description: codeReview.description,
-    argsSchema: codeReview.argsSchema,
-  },
-  codeReview.handler,
-);
-
+const server = createServer();
 const transport = new StdioServerTransport();
 
 try {
@@ -56,8 +25,12 @@ if (config.debug) {
 }
 
 const shutdown = async () => {
-  await transport.close();
-  process.exit(0);
+  try {
+    await transport.close();
+    process.exit(0);
+  } catch (error) {
+    fatal('Failed to close MCP server:', error);
+  }
 };
 
 process.on('SIGINT', shutdown);

--- a/src/prompts/hello.ts
+++ b/src/prompts/hello.ts
@@ -4,11 +4,14 @@ const LANGS = ['en', 'ko', 'ja'] as const;
 type Lang = (typeof LANGS)[number];
 
 export const name = 'hello';
+export const title = 'Hello';
 export const description = 'Generate a friendly greeting message';
 
-export const schema = {
+export const argsSchema = {
   language: z.enum(LANGS).optional().describe('Greeting language. Defaults to English.'),
 };
+
+export const schema = argsSchema;
 
 // `satisfies` (not `Record<string, string>`) keeps key narrowing under noUncheckedIndexedAccess.
 const greetings = {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,42 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import * as codeReview from './prompts/code-review.js';
+import * as hello from './prompts/hello.js';
+import { name, version } from './pkg.js';
+import * as serverInfo from './resources/server-info.js';
+import * as greet from './tools/greet.js';
+
+export function createServer() {
+  const server = new McpServer({
+    name,
+    version,
+  });
+
+  // Tools — use registerTool for full control (annotations, title).
+  server.registerTool(greet.name, greet.config, greet.handler);
+
+  // Resources — expose data to the client. Use registerResource for full control.
+  server.registerResource(serverInfo.name, serverInfo.uri, serverInfo.metadata, serverInfo.handler);
+
+  // Prompts — guided workflows for common tasks. Use registerPrompt for full control
+  // (title + description + argsSchema config object).
+  server.registerPrompt(
+    hello.name,
+    {
+      title: hello.title,
+      description: hello.description,
+      argsSchema: hello.argsSchema,
+    },
+    hello.handler,
+  );
+  server.registerPrompt(
+    codeReview.name,
+    {
+      title: codeReview.title,
+      description: codeReview.description,
+      argsSchema: codeReview.argsSchema,
+    },
+    codeReview.handler,
+  );
+
+  return server;
+}

--- a/tests/hello.test.js
+++ b/tests/hello.test.js
@@ -1,8 +1,14 @@
 import { describe, test, expect } from '@jest/globals';
 import { z } from 'zod';
-import { handler, schema, description } from '../dist/prompts/hello.js';
+import { handler, schema, argsSchema, name, title, description } from '../dist/prompts/hello.js';
 
 describe('hello prompt', () => {
+  test('has registerPrompt-ready metadata', () => {
+    expect(name).toBe('hello');
+    expect(title).toBe('Hello');
+    expect(argsSchema).toBe(schema);
+  });
+
   test('returns English greeting by default', () => {
     const result = handler({});
     expect(result.messages).toHaveLength(1);
@@ -27,7 +33,7 @@ describe('hello prompt', () => {
   });
 
   test('schema accepts supported languages and rejects unknown ones (Zod)', () => {
-    const shape = z.object(schema);
+    const shape = z.object(argsSchema);
     expect(shape.safeParse({}).success).toBe(true);
     expect(shape.safeParse({ language: 'en' }).success).toBe(true);
     expect(shape.safeParse({ language: 'ko' }).success).toBe(true);

--- a/tests/integration/server-boot.test.js
+++ b/tests/integration/server-boot.test.js
@@ -31,6 +31,7 @@ function makeDriver(child) {
   const pending = new Map();
   let nextId = 1;
   let buffer = '';
+  let stderr = '';
 
   child.stdout.setEncoding('utf8');
   child.stdout.on('data', (chunk) => {
@@ -48,6 +49,11 @@ function makeDriver(child) {
     }
   });
 
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
+
   function call(method, params) {
     const id = nextId++;
     const message = { jsonrpc: '2.0', id, method, params };
@@ -58,9 +64,13 @@ function makeDriver(child) {
       const watchdog = setTimeout(() => {
         if (pending.has(id)) {
           pending.delete(id);
-          reject(new Error(`Timeout waiting for response to ${method} (id=${id})`));
+          reject(
+            new Error(
+              `Timeout waiting for response to ${method} (id=${id}). stderr: ${stderr}`,
+            ),
+          );
         }
-      }, 3000);
+      }, 10000);
       watchdog.unref();
       pending.set(id, {
         resolve: (msg) => {
@@ -89,12 +99,6 @@ async function bootServer() {
     stdio: ['pipe', 'pipe', 'pipe'],
     env: { ...process.env, MCP_DEBUG: 'false' },
   });
-  // Drain stderr so the pipe buffer never fills (which would block the
-  // server). Don't fail on stderr content — it's the server's legit log
-  // channel.
-  child.stderr.setEncoding('utf8');
-  child.stderr.on('data', () => {});
-
   const driver = makeDriver(child);
 
   const initResult = await driver.call('initialize', {
@@ -141,6 +145,21 @@ describe('Server boot — dist/index.js spawned as a child process', () => {
     const greetTool = listResult.result?.tools?.find((t) => t.name === 'greet');
     expect(greetTool).toBeDefined();
     expect(greetTool.outputSchema).toBeDefined();
+  });
+
+  test('advertises resources and prompts through the actual binary', async () => {
+    const booted = await bootServer();
+    child = booted.child;
+
+    const resourcesResult = await booted.driver.call('resources/list', {});
+    expect(resourcesResult.result?.resources?.map((resource) => resource.uri)).toContain(
+      'info://server/status',
+    );
+
+    const promptsResult = await booted.driver.call('prompts/list', {});
+    expect(promptsResult.result?.prompts?.map((prompt) => prompt.name)).toEqual(
+      expect.arrayContaining(['hello', 'code-review']),
+    );
   });
 
   test('greet tool round-trips through the actual binary', async () => {

--- a/tests/integration/server-factory.test.js
+++ b/tests/integration/server-factory.test.js
@@ -1,0 +1,62 @@
+import { describe, test, expect } from '@jest/globals';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer } from '../../dist/server.js';
+
+async function buildLinkedPair() {
+  const server = createServer();
+  const client = new Client(
+    { name: 'starter-factory-test', version: '0.0.0' },
+    { capabilities: {} },
+  );
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+  return { server, client };
+}
+
+describe('server factory export', () => {
+  test('package root imports a side-effect-free createServer factory', async () => {
+    const root = await import('my-mcp-server');
+    expect(typeof root.createServer).toBe('function');
+  });
+
+  test('createServer registers tools, resources, and prompts', async () => {
+    const { server, client } = await buildLinkedPair();
+    try {
+      const [{ tools }, { resources }, { prompts }] = await Promise.all([
+        client.listTools(),
+        client.listResources(),
+        client.listPrompts(),
+      ]);
+
+      expect(tools.map((tool) => tool.name)).toContain('greet');
+      expect(resources.map((resource) => resource.uri)).toContain('info://server/status');
+      expect(prompts.map((prompt) => prompt.name)).toEqual(
+        expect.arrayContaining(['hello', 'code-review']),
+      );
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  test('hello prompt is registered through SDK prompt validation', async () => {
+    const { server, client } = await buildLinkedPair();
+    try {
+      const result = await client.getPrompt({
+        name: 'hello',
+        arguments: { language: 'ko' },
+      });
+
+      expect(result.messages?.[0]?.content).toEqual({
+        type: 'text',
+        text: '친근한 인사말을 작성해주세요.',
+      });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Split the reusable MCP server registration into `createServer()` and keep stdio startup in the CLI entrypoint.
- Align package `main`/`types`/`exports` so package-root imports are side-effect-free while `bin` and `npm start` still launch stdio.
- Move the `hello` prompt onto the `registerPrompt` metadata shape and add SDK integration coverage for tools, resources, prompts, package self-import, and stdio discovery.
- Update README HTTP examples to import the real `createServer()` export.

## README <-> code gaps checked before changes
| README claim | Code/test state before | Fix in this PR |
| --- | --- | --- |
| HTTP example calls `createServer()` | No exported server factory existed; root export pointed at the stdio entrypoint. | Added `src/server.ts` with `createServer()` and exported it as package root. |
| Prompts use `registerPrompt` | `code-review` used `registerPrompt`, but `hello` used the older `server.prompt()` path. | Added `title`/`argsSchema` metadata to `hello` and registered it through `registerPrompt`. |
| Package is a publishable MCP server starter | `main`/root export imported the executable entrypoint, so programmatic import could start stdio. | `main`, `types`, and `exports['.']` now target `dist/server.*`; CLI remains at `dist/index.js`. |
| Stdio/resources/prompts are implemented | Boot test covered initialize/tools only. | Boot test now checks resources/prompts; factory test checks SDK registration and package self-import. |

## Validation
- `npm test`
- `npm run lint`
- `npm run build`
- `npm audit --audit-level=high` (exit 0; remaining advisory is moderate in Jest coverage chain)
- `npm pack --dry-run --json`
- Manual MCP stdio smoke against `node dist/index.js` for initialize, tools/list, resources/list, prompts/list, and greet structuredContent.
