### PR TITLE
ci: harden workflow inputs

### DIFF
--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -28,7 +28,7 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         if: steps.gate.outputs.skip == 'false'
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -65,6 +65,8 @@ jobs:
           mv CHANGELOG.md.new CHANGELOG.md
 
       - name: Commit and push
+        env:
+          TAG: ${{ github.event.release.tag_name }}
         run: |
           if git diff --quiet -- CHANGELOG.md; then
             echo "No changes to CHANGELOG.md — release body was empty?"
@@ -73,5 +75,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add CHANGELOG.md
-          git commit -m "docs(changelog): record ${{ github.event.release.tag_name }} [skip ci]"
+          git commit -m "docs(changelog): record ${TAG} [skip ci]"
           git push


### PR DESCRIPTION
## Summary
- Applies the verified security/hardening fix for this repository's touched surface.
- Keeps the change scoped to the audited issue family and avoids unrelated cleanup.
- Leaves out preserved local-only work that belongs to a separate decision.

## Local Verification
- Repo-specific lint/test/build/package checks were run before commit where applicable.
- Staged whitespace checks passed before commit.
- CI on this PR is the merge gate.